### PR TITLE
ft(reader-frontend): connect public articles API to Blogs page and ar…

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,13 +1,10 @@
 import React from "react";
 import { Routes, Route, useLocation } from "react-router-dom";
-
-// Components
 import Navbar from "./components/navbar";
 import Footer from "./components/footer";
-
-// Pages
 import HomePage from "./pages/Home";
 import BlogsPage from "./pages/Blogs";
+import ArticleDetailPage from "./pages/ArticleDetail";
 import VerifyPage from "./pages/Verify";
 import SignInPage from "./pages/Signin";
 import SignUpPage from "./pages/Signup";
@@ -18,21 +15,20 @@ import DashboardPage from "./pages/Dashboard";
 const App: React.FC = () => {
   const location = useLocation();
 
-  // Define paths where Navbar and Footer should NOT be displayed
   const authRoutes = ["/signin", "/signup", "/verify-request", "/dashboard"];
-  const shouldHideLayout = authRoutes.includes(location.pathname);
+  const shouldHideLayout =
+    authRoutes.includes(location.pathname) || location.pathname.startsWith("/articles/");
 
   return (
     <>
-      {/* Conditionally render Navbar */}
       {!shouldHideLayout && <Navbar />}
 
       <main className="min-h-screen">
         <Routes>
           <Route path="/" element={<HomePage />} />
           <Route path="/blogs" element={<BlogsPage />} />
+          <Route path="/articles/:slug" element={<ArticleDetailPage />} />
           <Route path="/verify-request" element={<VerifyPage />} />
-
           <Route path="/signin" element={<SignInPage />} />
           <Route path="/signup" element={<SignUpPage />} />
           <Route path="/contact" element={<ContactPage />} />
@@ -41,7 +37,6 @@ const App: React.FC = () => {
         </Routes>
       </main>
 
-      {/* Conditionally render Footer */}
       {!shouldHideLayout && <Footer />}
     </>
   );

--- a/client/src/pages/ArticleDetail.tsx
+++ b/client/src/pages/ArticleDetail.tsx
@@ -1,0 +1,166 @@
+import { useEffect, useState } from "react";
+import { useParams, Link } from "react-router-dom";
+import { FaArrowLeft, FaClock, FaCalendar } from "react-icons/fa";
+import { FaFeatherAlt } from "react-icons/fa";
+import { getArticleBySlug } from "@/lib/api/reader";
+import type { PublicArticle } from "@/types/reader";
+
+const QUILL_PROSE = `
+  .article-body h1, .article-body h2, .article-body h3 { font-family: 'Playfair Display', serif; color: #1a1a1a; margin: 1.5em 0 0.5em; }
+  .article-body h1 { font-size: 2rem; }
+  .article-body h2 { font-size: 1.5rem; }
+  .article-body h3 { font-size: 1.25rem; }
+  .article-body p { color: #3a3a3a; line-height: 1.85; margin-bottom: 1.25em; font-size: 1.0625rem; }
+  .article-body a { color: #d97706; text-decoration: underline; }
+  .article-body blockquote { border-left: 3px solid #fbbf24; padding-left: 1.25rem; color: #6b6b6b; font-style: italic; margin: 1.5em 0; }
+  .article-body ul, .article-body ol { padding-left: 1.5rem; margin-bottom: 1.25em; color: #3a3a3a; line-height: 1.85; }
+  .article-body li { margin-bottom: 0.4em; }
+  .article-body pre { background: #f0ede7; border-radius: 10px; padding: 1rem 1.25rem; overflow-x: auto; margin-bottom: 1.25em; }
+  .article-body code { font-family: monospace; font-size: 0.9rem; color: #1a1a1a; }
+  .article-body img { max-width: 100%; border-radius: 12px; margin: 1.5em 0; }
+`;
+
+const formatDate = (iso: string) =>
+  new Date(iso).toLocaleDateString("en-US", { weekday: "long", month: "long", day: "numeric", year: "numeric" });
+
+const readingTime = (html: string) => {
+  const words = html.replace(/<[^>]*>/g, "").trim().split(/\s+/).filter(Boolean).length;
+  return Math.max(1, Math.ceil(words / 200));
+};
+
+const authorInitials = (name: string) =>
+  name.split(" ").map((n) => n[0]).join("").slice(0, 2).toUpperCase();
+
+const ACCENT_COLORS = ["#E8A838", "#5B8DEF", "#3DBDA7", "#E87B5B", "#9B7FE8"];
+const accentFor = (id: string) => ACCENT_COLORS[id.charCodeAt(0) % ACCENT_COLORS.length];
+
+const ArticleDetailPage = () => {
+  const { slug } = useParams<{ slug: string }>();
+  const [article, setArticle] = useState<PublicArticle | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [notFound, setNotFound] = useState(false);
+
+  useEffect(() => {
+    if (!slug) return;
+    setLoading(true);
+    setNotFound(false);
+    getArticleBySlug(slug)
+      .then((res) => setArticle(res.data))
+      .catch(() => setNotFound(true))
+      .finally(() => setLoading(false));
+  }, [slug]);
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-[#F8F6F1] flex items-center justify-center">
+        <div className="w-8 h-8 rounded-full border-2 border-amber-400 border-t-transparent animate-spin" />
+      </div>
+    );
+  }
+
+  if (notFound || !article) {
+    return (
+      <div className="min-h-screen bg-[#F8F6F1] flex flex-col items-center justify-center gap-4 px-6">
+        <FaFeatherAlt size={36} className="text-amber-400/40" />
+        <h1 className="text-[#1a1a1a] text-2xl font-bold font-playfair">Article not found</h1>
+        <p className="text-[#6b6b6b] text-sm">It may have been removed or the link is incorrect.</p>
+        <Link
+          to="/blogs"
+          className="inline-flex items-center gap-2 text-amber-600 font-medium text-sm hover:underline mt-2"
+        >
+          <FaArrowLeft size={12} /> Back to all posts
+        </Link>
+      </div>
+    );
+  }
+
+  const color = accentFor(article.article_id);
+  const mins = readingTime(article.content);
+
+  return (
+    <div style={{ fontFamily: "'DM Sans', sans-serif" }}>
+      <style>{QUILL_PROSE}</style>
+
+      <div className="bg-[#0C0C0C] pt-24 pb-12 px-6">
+        <div className="max-w-3xl mx-auto">
+          <Link
+            to="/blogs"
+            className="inline-flex items-center gap-2 text-white/40 hover:text-white/70 text-sm transition-colors mb-8"
+          >
+            <FaArrowLeft size={11} /> All posts
+          </Link>
+
+          <h1 className="text-white text-3xl sm:text-4xl md:text-5xl font-bold leading-tight mb-6 font-playfair">
+            {article.title}
+          </h1>
+
+          <div className="flex flex-wrap items-center gap-5 text-white/40 text-sm">
+            <div className="flex items-center gap-2.5">
+              <div
+                className="w-8 h-8 rounded-full flex items-center justify-center text-xs font-bold text-white shrink-0"
+                style={{ backgroundColor: color }}
+              >
+                {authorInitials(article.author.fullname)}
+              </div>
+              <span className="text-white/70 font-medium">{article.author.fullname}</span>
+            </div>
+            <span className="flex items-center gap-1.5">
+              <FaCalendar size={11} className="text-amber-400/60" />
+              {formatDate(article.published_at)}
+            </span>
+            <span className="flex items-center gap-1.5">
+              <FaClock size={11} className="text-amber-400/60" />
+              {mins} min read
+            </span>
+          </div>
+        </div>
+      </div>
+
+      {article.cover_image && (
+        <div className="max-w-4xl mx-auto px-6 -mt-1">
+          <img
+            src={article.cover_image}
+            alt={article.title}
+            className="w-full rounded-2xl object-cover max-h-96"
+          />
+        </div>
+      )}
+
+      <main className="bg-[#F8F6F1] px-6 py-14">
+        <div className="max-w-3xl mx-auto">
+          {article.author.bio && (
+            <div className="flex items-start gap-4 bg-white border border-[#E8E4DC] rounded-2xl p-5 mb-10">
+              <div
+                className="w-10 h-10 rounded-full flex items-center justify-center text-sm font-bold text-white shrink-0"
+                style={{ backgroundColor: color }}
+              >
+                {authorInitials(article.author.fullname)}
+              </div>
+              <div>
+                <p className="text-[#1a1a1a] text-sm font-semibold mb-0.5">{article.author.fullname}</p>
+                <p className="text-[#6b6b6b] text-xs leading-relaxed">{article.author.bio}</p>
+              </div>
+            </div>
+          )}
+
+          <div
+            className="article-body"
+            dangerouslySetInnerHTML={{ __html: article.content }}
+          />
+
+          <div className="mt-14 pt-10 border-t border-[#E8E4DC] flex items-center justify-between flex-wrap gap-4">
+            <Link
+              to="/blogs"
+              className="inline-flex items-center gap-2 text-amber-600 font-medium text-sm hover:underline"
+            >
+              <FaArrowLeft size={12} /> Back to all posts
+            </Link>
+            <p className="text-[#9b9b9b] text-xs">Published on {formatDate(article.published_at)}</p>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default ArticleDetailPage;

--- a/client/src/pages/Blogs.tsx
+++ b/client/src/pages/Blogs.tsx
@@ -1,284 +1,132 @@
-import { useState, useMemo } from "react";
-import {
-  FaSearch,
-  FaShieldAlt,
-  FaArrowRight,
-  FaClock,
-  FaTimes,
-} from "react-icons/fa";
+import { useState, useEffect, useCallback, useRef } from "react";
+import { FaSearch, FaArrowRight, FaClock, FaTimes } from "react-icons/fa";
+import { FaFeatherAlt } from "react-icons/fa";
 import { Link } from "react-router-dom";
+import { getPublicArticles } from "@/lib/api/reader";
+import type { PublicArticle } from "@/types/reader";
 
-interface Post {
-  id: number;
-  category: string;
-  title: string;
-  excerpt: string;
-  author: string;
-  role: string;
-  initials: string;
-  accentColor: string;
-  image: string;
-  imageAlt: string;
-  readTime: string;
-  date: string;
-  featured?: boolean;
-}
+const formatDate = (iso: string) =>
+  new Date(iso).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
 
-const ALL_POSTS: Post[] = [
-  {
-    id: 1,
-    category: "Design",
-    title: "The Invisible Grid: How Whitespace Shapes Reader Trust",
-    excerpt:
-      "Great design isn't about what you add — it's about the breath you leave between ideas. Here's how whitespace communicates credibility.",
-    author: "Amara Osei",
-    role: "Product Designer",
-    initials: "AO",
-    accentColor: "#E8A838",
-    image:
-      "https://images.unsplash.com/photo-1618005182384-a83a8bd57fbe?w=700&q=80&auto=format&fit=crop",
-    imageAlt: "Abstract colourful design shapes",
-    readTime: "5 min",
-    date: "Mar 28, 2025",
-    featured: true,
-  },
-  {
-    id: 2,
-    category: "Engineering",
-    title: "Building for the Long Run: Why Boring Tech Wins",
-    excerpt:
-      "Chasing trends is tempting. But the most resilient products are built on dull, proven foundations that scale quietly for years.",
-    author: "James Mwangi",
-    role: "Senior Engineer",
-    initials: "JM",
-    accentColor: "#5B8DEF",
-    image:
-      "https://images.unsplash.com/photo-1555066931-4365d14bab8c?w=700&q=80&auto=format&fit=crop",
-    imageAlt: "Code on a dark monitor screen",
-    readTime: "7 min",
-    date: "Mar 25, 2025",
-  },
-  {
-    id: 3,
-    category: "Writing",
-    title: "The First Sentence Is Everything — Here's How to Write One",
-    excerpt:
-      "Readers decide within three seconds. A masterful opening doesn't announce itself — it simply pulls you forward without asking.",
-    author: "Lena Kovač",
-    role: "Journalist & Author",
-    initials: "LK",
-    accentColor: "#3DBDA7",
-    image:
-      "https://images.unsplash.com/photo-1455390582262-044cdead277a?w=700&q=80&auto=format&fit=crop",
-    imageAlt: "Open notebook with a pen on a wooden desk",
-    readTime: "4 min",
-    date: "Mar 22, 2025",
-  },
-  {
-    id: 4,
-    category: "Culture",
-    title: "What Slow Journalism Can Teach Modern Content Creators",
-    excerpt:
-      "In the race to publish first, we've forgotten the value of depth. Slow journalism offers a radical counter-model worth revisiting.",
-    author: "Sophie Renault",
-    role: "Culture Writer",
-    initials: "SR",
-    accentColor: "#E87B5B",
-    image:
-      "https://images.unsplash.com/photo-1504711434969-e33886168f5c?w=700&q=80&auto=format&fit=crop",
-    imageAlt: "Vintage newspaper spread on a table",
-    readTime: "6 min",
-    date: "Mar 19, 2025",
-  },
-  {
-    id: 5,
-    category: "Tech",
-    title: "The Quiet Revolution of Edge Computing",
-    excerpt:
-      "Data processing is moving closer to where it's generated. Here's why this silent shift matters more than any headline AI announcement.",
-    author: "Daniel Achebe",
-    role: "Systems Architect",
-    initials: "DA",
-    accentColor: "#9B7FE8",
-    image:
-      "https://images.unsplash.com/photo-1558494949-ef010cbdcc31?w=700&q=80&auto=format&fit=crop",
-    imageAlt: "Server room with blue lighting",
-    readTime: "8 min",
-    date: "Mar 16, 2025",
-  },
-  {
-    id: 6,
-    category: "Life",
-    title: "On Working Slowly in a World That Rewards Speed",
-    excerpt:
-      "We glorify hustle but admire craft. This contradiction is at the heart of every burned-out creator who ever quit their newsletter.",
-    author: "Kwame Asante",
-    role: "Essayist",
-    initials: "KA",
-    accentColor: "#3DBDA7",
-    image:
-      "https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=700&q=80&auto=format&fit=crop",
-    imageAlt: "Person sitting quietly by a mountain lake",
-    readTime: "5 min",
-    date: "Mar 12, 2025",
-  },
-  {
-    id: 7,
-    category: "Design",
-    title: "Dark Mode Is Not an Aesthetic — It's an Accessibility Choice",
-    excerpt:
-      "Too many teams treat dark mode as a cosmetic toggle. When you understand who actually needs it, everything about how you build it changes.",
-    author: "Amara Osei",
-    role: "Product Designer",
-    initials: "AO",
-    accentColor: "#E8A838",
-    image:
-      "https://images.unsplash.com/photo-1550751827-4bd374c3f58b?w=700&q=80&auto=format&fit=crop",
-    imageAlt: "Dark UI design on a laptop screen",
-    readTime: "6 min",
-    date: "Mar 9, 2025",
-  },
-  {
-    id: 8,
-    category: "Writing",
-    title: "Why Your Draft Is Probably One Revision Away from Great",
-    excerpt:
-      "Most writers abandon pieces that are a single ruthless edit away from something worth reading. Here's how to tell the difference.",
-    author: "Lena Kovač",
-    role: "Journalist & Author",
-    initials: "LK",
-    accentColor: "#3DBDA7",
-    image:
-      "https://images.unsplash.com/photo-1499750310107-5fef28a66643?w=700&q=80&auto=format&fit=crop",
-    imageAlt: "Writer working at a desk with coffee",
-    readTime: "4 min",
-    date: "Mar 6, 2025",
-  },
-  {
-    id: 9,
-    category: "Engineering",
-    title: "Type Systems Are Love Letters to Your Future Self",
-    excerpt:
-      "Six months from now, you won't remember why you wrote that function. TypeScript will — and it'll save you from yourself.",
-    author: "James Mwangi",
-    role: "Senior Engineer",
-    initials: "JM",
-    accentColor: "#5B8DEF",
-    image:
-      "https://images.unsplash.com/photo-1516116216624-53e697fedbea?w=700&q=80&auto=format&fit=crop",
-    imageAlt: "Closeup of TypeScript code",
-    readTime: "7 min",
-    date: "Mar 3, 2025",
-  },
-];
+const readingTime = (html: string) => {
+  const words = html.replace(/<[^>]*>/g, "").trim().split(/\s+/).filter(Boolean).length;
+  return Math.max(1, Math.ceil(words / 200));
+};
 
-const CATEGORIES = [
-  "All",
-  "Design",
-  "Engineering",
-  "Writing",
-  "Culture",
-  "Tech",
-  "Life",
-];
+const authorInitials = (name: string) =>
+  name
+    .split(" ")
+    .map((n) => n[0])
+    .join("")
+    .slice(0, 2)
+    .toUpperCase();
 
-const PostCard = ({ post, delay = 0 }: { post: Post; delay?: number }) => {
+const ACCENT_COLORS = ["#E8A838", "#5B8DEF", "#3DBDA7", "#E87B5B", "#9B7FE8"];
+const accentFor = (id: string) => ACCENT_COLORS[id.charCodeAt(0) % ACCENT_COLORS.length];
+
+const ArticleCard = ({ article }: { article: PublicArticle }) => {
+  const color = accentFor(article.article_id);
+  const mins = readingTime(article.content);
+
   return (
-    <article
-      className="group bg-white rounded-2xl overflow-hidden border border-[#E8E4DC] hover:border-amber-200 hover:shadow-2xl hover:shadow-amber-50/80 transition-all duration-500 cursor-pointer flex flex-col"
-      style={{ animationDelay: `${delay}ms` }}
+    <Link
+      to={`/articles/${article.slug}`}
+      className="group bg-white rounded-2xl overflow-hidden border border-[#E8E4DC] hover:border-amber-200 hover:shadow-2xl hover:shadow-amber-50/80 transition-all duration-500 flex flex-col"
     >
-      <div className="relative overflow-hidden h-44 bg-[#F0EDE7] shrink-0">
-        <img
-          src={post.image}
-          alt={post.imageAlt}
-          className="w-full h-full object-cover transition-transform duration-700 group-hover:scale-105"
-          loading="lazy"
-        />
-        <span
-          className="absolute top-3 left-3 text-[10px] font-bold tracking-widest uppercase px-3 py-1.5 rounded-full text-white shadow-md"
-          style={{ backgroundColor: post.accentColor }}
-        >
-          {post.category}
-        </span>
-      </div>
+      {article.cover_image ? (
+        <div className="relative overflow-hidden h-44 bg-[#F0EDE7] shrink-0">
+          <img
+            src={article.cover_image}
+            alt={article.title}
+            className="w-full h-full object-cover transition-transform duration-700 group-hover:scale-105"
+            loading="lazy"
+          />
+        </div>
+      ) : (
+        <div className="h-44 shrink-0 flex items-center justify-center" style={{ backgroundColor: `${color}15` }}>
+          <FaFeatherAlt size={28} style={{ color }} className="opacity-40" />
+        </div>
+      )}
 
       <div className="p-6 flex flex-col flex-1">
         <h3
-          className="text-[#1A1A1A] font-bold text-lg leading-snug mb-2.5 group-hover:text-amber-700 transition-colors duration-200 flex-1"
-          style={{ fontFamily: "'Playfair Display', serif" }}
+          className="text-[#1A1A1A] font-bold text-lg leading-snug mb-2.5 group-hover:text-amber-700 transition-colors duration-200 flex-1 font-playfair"
         >
-          {post.title}
+          {article.title}
         </h3>
         <p className="text-[#6B6B6B] text-sm leading-relaxed mb-5 line-clamp-2">
-          {post.excerpt}
+          {article.content.replace(/<[^>]*>/g, "").slice(0, 120)}…
         </p>
 
         <div className="flex items-center justify-between pt-4 border-t border-[#F0EDE7]">
           <div className="flex items-center gap-2.5">
             <div
               className="w-7 h-7 rounded-full flex items-center justify-center text-[10px] font-bold text-white shrink-0"
-              style={{ backgroundColor: post.accentColor }}
+              style={{ backgroundColor: color }}
             >
-              {post.initials}
+              {authorInitials(article.author.fullname)}
             </div>
             <div>
-              <p className="text-[#1A1A1A] text-xs font-semibold leading-tight">
-                {post.author}
-              </p>
-              <p className="text-[#9B9B9B] text-[10px]">{post.date}</p>
+              <p className="text-[#1A1A1A] text-xs font-semibold leading-tight">{article.author.fullname}</p>
+              <p className="text-[#9B9B9B] text-[10px]">{formatDate(article.published_at)}</p>
             </div>
           </div>
           <div className="flex items-center gap-1 text-[#9B9B9B] text-xs">
             <FaClock size={10} className="text-amber-400" />
-            <span>{post.readTime} read</span>
+            <span>{mins} min read</span>
           </div>
         </div>
       </div>
-    </article>
+    </Link>
   );
 };
 
-const FeaturedCard = ({ post }: { post: Post }) => {
+const FeaturedCard = ({ article }: { article: PublicArticle }) => {
+  const color = accentFor(article.article_id);
+  const mins = readingTime(article.content);
+
   return (
-    <article className="group relative rounded-3xl overflow-hidden cursor-pointer h-105 md:h-120">
-      <img
-        src={post.image}
-        alt={post.imageAlt}
-        className="absolute inset-0 w-full h-full object-cover transition-transform duration-700 group-hover:scale-105"
-      />
+    <Link
+      to={`/articles/${article.slug}`}
+      className="group relative rounded-3xl overflow-hidden block"
+      style={{ minHeight: "420px" }}
+    >
+      {article.cover_image ? (
+        <img
+          src={article.cover_image}
+          alt={article.title}
+          className="absolute inset-0 w-full h-full object-cover transition-transform duration-700 group-hover:scale-105"
+        />
+      ) : (
+        <div
+          className="absolute inset-0"
+          style={{ background: `linear-gradient(135deg, ${color}22, ${color}08)` }}
+        />
+      )}
       <div className="absolute inset-0 bg-linear-to-t from-[#0C0C0C] via-[#0C0C0C]/50 to-transparent" />
 
       <div className="absolute bottom-0 left-0 right-0 p-8">
-        <span
-          className="inline-block text-[10px] font-bold tracking-widest uppercase px-3 py-1.5 rounded-full text-white mb-4"
-          style={{ backgroundColor: post.accentColor }}
-        >
-          {post.category}
-        </span>
         <h2
-          className="text-white text-3xl md:text-4xl font-bold leading-snug mb-3"
-          style={{ fontFamily: "'Playfair Display', serif" }}
+          className="text-white text-3xl md:text-4xl font-bold leading-snug mb-3 font-playfair"
         >
-          {post.title}
+          {article.title}
         </h2>
         <p className="text-white/60 text-sm leading-relaxed mb-6 max-w-xl">
-          {post.excerpt}
+          {article.content.replace(/<[^>]*>/g, "").slice(0, 160)}…
         </p>
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
             <div
-              className="w-9 h-9 rounded-full flex items-center justify-center text-xs font-bold text-white"
-              style={{ backgroundColor: post.accentColor }}
+              className="w-9 h-9 rounded-full flex items-center justify-center text-xs font-bold text-white shrink-0"
+              style={{ backgroundColor: color }}
             >
-              {post.initials}
+              {authorInitials(article.author.fullname)}
             </div>
             <div>
-              <p className="text-white text-sm font-semibold">{post.author}</p>
-              <div className="flex items-center gap-1.5">
-                <FaShieldAlt size={9} className="text-amber-400" />
-                <p className="text-white/40 text-xs">{post.role}</p>
-              </div>
+              <p className="text-white text-sm font-semibold">{article.author.fullname}</p>
+              <p className="text-white/40 text-xs">
+                {mins} min read · {formatDate(article.published_at)}
+              </p>
             </div>
           </div>
           <span className="inline-flex items-center gap-2 text-white/70 hover:text-white text-sm font-medium group-hover:gap-3 transition-all duration-200">
@@ -286,32 +134,60 @@ const FeaturedCard = ({ post }: { post: Post }) => {
           </span>
         </div>
       </div>
-    </article>
+    </Link>
   );
 };
 
 const BlogsPage = () => {
-  const [activeCategory, setActiveCategory] = useState("All");
+  const [articles, setArticles] = useState<PublicArticle[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
   const [query, setQuery] = useState("");
+  const [debouncedQuery, setDebouncedQuery] = useState("");
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const featured = ALL_POSTS.find((p) => p.featured)!;
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      setDebouncedQuery(query);
+      setPage(1);
+      setArticles([]);
+    }, 400);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [query]);
 
-  const filtered = useMemo(() => {
-    return ALL_POSTS.filter((p) => {
-      const matchCat =
-        activeCategory === "All" || p.category === activeCategory;
-      const matchQ =
-        query.trim() === "" ||
-        p.title.toLowerCase().includes(query.toLowerCase()) ||
-        p.excerpt.toLowerCase().includes(query.toLowerCase()) ||
-        p.author.toLowerCase().includes(query.toLowerCase());
-      return matchCat && matchQ;
-    });
-  }, [activeCategory, query]);
-
-  const gridPosts = filtered.filter(
-    (p) => !p.featured || activeCategory !== "All" || query !== "",
+  const fetchArticles = useCallback(
+    async (pageNum: number, append: boolean) => {
+      if (pageNum === 1 && !append) setLoading(true);
+      else setLoadingMore(true);
+      try {
+        const res = await getPublicArticles({
+          page: pageNum,
+          pageSize: 9,
+          search: debouncedQuery || undefined,
+        });
+        const incoming = res.data.data;
+        setArticles((prev) => (append ? [...prev, ...incoming] : incoming));
+        setTotalPages(res.data.totalPages);
+      } catch {
+      } finally {
+        setLoading(false);
+        setLoadingMore(false);
+      }
+    },
+    [debouncedQuery],
   );
+
+  useEffect(() => {
+    fetchArticles(page, page > 1);
+  }, [page, fetchArticles]);
+
+  const featured = articles[0] ?? null;
+  const gridArticles = articles.slice(1);
 
   return (
     <div style={{ fontFamily: "'DM Sans', sans-serif" }}>
@@ -323,22 +199,15 @@ const BlogsPage = () => {
           <p className="text-amber-400 text-xs font-semibold tracking-widest uppercase mb-3">
             The Insight Press Journal
           </p>
-          <h1
-            className="text-5xl sm:text-6xl font-bold text-white mb-4 leading-tight"
-            style={{ fontFamily: "'Playfair Display', serif" }}
-          >
+          <h1 className="text-5xl sm:text-6xl font-bold text-white mb-4 leading-tight font-playfair">
             Stories worth reading.
           </h1>
           <p className="text-white/40 text-lg max-w-xl mb-10">
-            Curated posts from verified authors across design, engineering,
-            writing, and culture.
+            Curated posts from verified authors across design, engineering, writing, and culture.
           </p>
 
           <div className="relative max-w-md">
-            <FaSearch
-              size={13}
-              className="absolute left-4 top-1/2 -translate-y-1/2 text-white/30"
-            />
+            <FaSearch size={13} className="absolute left-4 top-1/2 -translate-y-1/2 text-white/30" />
             <input
               type="text"
               value={query}
@@ -358,113 +227,79 @@ const BlogsPage = () => {
         </div>
       </section>
 
-      <div className="bg-[#0C0C0C] border-b border-white/6 px-6 pb-5">
-        <div className="max-w-6xl mx-auto flex items-center gap-2.5 overflow-x-auto pb-1 scrollbar-hide">
-          {CATEGORIES.map((cat) => {
-            const isActive = activeCategory === cat;
-            return (
-              <button
-                key={cat}
-                onClick={() => setActiveCategory(cat)}
-                className={`shrink-0 text-xs font-semibold px-4 py-2 rounded-full transition-all duration-200 ${
-                  isActive
-                    ? "bg-amber-400 text-[#0C0C0C]"
-                    : "bg-white/5 text-white/50 hover:text-white hover:bg-white/8 border border-white/8"
-                }`}
-              >
-                {cat}
-                {cat !== "All" && isActive && (
-                  <span className="ml-1.5 opacity-60">
-                    ({ALL_POSTS.filter((p) => p.category === cat).length})
-                  </span>
-                )}
-              </button>
-            );
-          })}
-        </div>
-      </div>
-
       <main className="bg-[#F8F6F1] px-6 py-16">
         <div className="max-w-6xl mx-auto">
-          {activeCategory === "All" && query === "" && (
-            <div className="mb-12">
-              <p className="text-amber-600 text-xs font-semibold tracking-widest uppercase mb-5">
-                Featured Post
-              </p>
-              <FeaturedCard post={featured} />
-            </div>
-          )}
-
-          {(query || activeCategory !== "All") && (
-            <p className="text-[#6B6B6B] text-sm mb-8">
-              Showing{" "}
-              <span className="text-[#1A1A1A] font-semibold">
-                {filtered.length}
-              </span>{" "}
-              {filtered.length === 1 ? "post" : "posts"}
-              {activeCategory !== "All" && (
-                <>
-                  {" "}
-                  in{" "}
-                  <span className="text-[#1A1A1A] font-semibold">
-                    {activeCategory}
-                  </span>
-                </>
-              )}
-              {query && (
-                <>
-                  {" "}
-                  for "
-                  <span className="text-[#1A1A1A] font-semibold">{query}</span>"
-                </>
-              )}
-            </p>
-          )}
-
-          {gridPosts.length > 0 ? (
-            <>
-              {activeCategory === "All" && query === "" && (
-                <p className="text-amber-600 text-xs font-semibold tracking-widest uppercase mb-5">
-                  Latest Posts
-                </p>
-              )}
+          {loading ? (
+            <div className="space-y-8">
+              <div className="h-96 bg-[#E8E4DC] rounded-3xl animate-pulse" />
               <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-                {(activeCategory === "All" && query === ""
-                  ? gridPosts
-                  : filtered
-                ).map((post, i) => (
-                  <PostCard key={post.id} post={post} delay={i * 60} />
+                {[...Array(6)].map((_, i) => (
+                  <div key={i} className="h-80 bg-[#E8E4DC] rounded-2xl animate-pulse" />
                 ))}
               </div>
-
-              <div className="mt-14 text-center">
-                <button className="inline-flex items-center gap-2 bg-white border border-[#E8E4DC] hover:border-amber-300 text-[#1A1A1A] font-semibold px-8 py-3.5 rounded-full transition-all duration-200 hover:shadow-lg hover:shadow-amber-100 text-sm">
-                  Load more posts
-                </button>
-              </div>
-            </>
-          ) : (
+            </div>
+          ) : articles.length === 0 ? (
             <div className="text-center py-24">
               <p className="text-5xl mb-4">🔍</p>
-              <h3
-                className="text-[#1A1A1A] text-2xl font-bold mb-2"
-                style={{ fontFamily: "'Playfair Display', serif" }}
-              >
+              <h3 className="text-[#1A1A1A] text-2xl font-bold mb-2 font-playfair">
                 No posts found
               </h3>
-              <p className="text-[#6B6B6B] text-sm">
-                Try a different search term or category.
-              </p>
-              <button
-                onClick={() => {
-                  setQuery("");
-                  setActiveCategory("All");
-                }}
-                className="mt-6 text-amber-600 text-sm font-medium hover:underline"
-              >
-                Clear filters
-              </button>
+              <p className="text-[#6B6B6B] text-sm">Try a different search term.</p>
+              {query && (
+                <button
+                  onClick={() => setQuery("")}
+                  className="mt-6 text-amber-600 text-sm font-medium hover:underline"
+                >
+                  Clear search
+                </button>
+              )}
             </div>
+          ) : (
+            <>
+              {!debouncedQuery && featured && (
+                <div className="mb-12">
+                  <p className="text-amber-600 text-xs font-semibold tracking-widest uppercase mb-5">
+                    Featured Post
+                  </p>
+                  <FeaturedCard article={featured} />
+                </div>
+              )}
+
+              {debouncedQuery && (
+                <p className="text-[#6B6B6B] text-sm mb-8">
+                  Showing <span className="text-[#1A1A1A] font-semibold">{articles.length}</span>{" "}
+                  {articles.length === 1 ? "post" : "posts"} for "
+                  <span className="text-[#1A1A1A] font-semibold">{debouncedQuery}</span>"
+                </p>
+              )}
+
+              {(!debouncedQuery && gridArticles.length > 0) || debouncedQuery ? (
+                <>
+                  {!debouncedQuery && (
+                    <p className="text-amber-600 text-xs font-semibold tracking-widest uppercase mb-5">
+                      Latest Posts
+                    </p>
+                  )}
+                  <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                    {(debouncedQuery ? articles : gridArticles).map((article) => (
+                      <ArticleCard key={article.article_id} article={article} />
+                    ))}
+                  </div>
+                </>
+              ) : null}
+
+              {page < totalPages && (
+                <div className="mt-14 text-center">
+                  <button
+                    onClick={() => setPage((p) => p + 1)}
+                    disabled={loadingMore}
+                    className="inline-flex items-center gap-2 bg-white border border-[#E8E4DC] hover:border-amber-300 text-[#1A1A1A] font-semibold px-8 py-3.5 rounded-full transition-all duration-200 hover:shadow-lg hover:shadow-amber-100 text-sm disabled:opacity-50"
+                  >
+                    {loadingMore ? "Loading…" : "Load more posts"}
+                  </button>
+                </div>
+              )}
+            </>
           )}
         </div>
       </main>
@@ -472,15 +307,10 @@ const BlogsPage = () => {
       <section className="bg-[#0C0C0C] px-6 py-16">
         <div className="max-w-6xl mx-auto flex flex-col md:flex-row items-center justify-between gap-6">
           <div>
-            <h3
-              className="text-white text-3xl font-bold mb-2"
-              style={{ fontFamily: "'Playfair Display', serif" }}
-            >
+            <h3 className="text-white text-3xl font-bold mb-2 font-playfair">
               Have a story to tell?
             </h3>
-            <p className="text-white/40 text-sm">
-              Get verified and publish your first post today.
-            </p>
+            <p className="text-white/40 text-sm">Get verified and publish your first post today.</p>
           </div>
           <Link
             to="/verify-request"


### PR DESCRIPTION
…ticle detail

- Blogs: replaces static mock data with paginated real articles from getPublicArticles, debounced search, load-more pagination, dynamic accent colors per author
- ArticleDetail: new page at /articles/:slug that fetches and renders a single article with Quill HTML content, author bio card, reading time, cover image
- App: adds /articles/:slug route, hides navbar/footer on article detail pages, removes stale comments